### PR TITLE
Make conkeyrefs resolve

### DIFF
--- a/ditatodocbook.sh
+++ b/ditatodocbook.sh
@@ -191,6 +191,31 @@ for sourcefile in $sourcefiles; do
   done
 done
 
+
+# Resolve conkeyref
+CONKEYREFS="HOS-conrefs.xml"
+# install_entryscale_kvm twosystems hw_support_hardwareconfig
+
+# Search for this file in different parent directories:
+for parent in "." ".." "../.."; do
+  if [[ -e $parent/$CONKEYREFS ]]; then
+    CONKEYREFS=$basedir/$parent/$CONKEYREFS
+    break
+  fi
+done
+
+echo "Using conkeyref file $CONKEYREFS"
+
+for sourcefile in $sourcefiles; do
+   echo ">> Resolving conkeyrefs for $sourcefile"
+   xsltproc \
+     --stringparam conrefs.file $CONKEYREFS \
+    "$mydir/resolve-conkeyref.xsl" \
+     "$tmpdir/$sourcefile" > "$tmpdir/$sourcefile-0"
+   mv "$tmpdir/$sourcefile-0" "$tmpdir/$sourcefile"
+done
+
+
 ## Modify the original DITA files to get rid of duplicate IDs.
 tempsourcefiles=$(echo $sourcefiles | sed -r "s,[^ ]+,$tmpdir/&,g")
 allids=$(xsltproc --stringparam 'name' 'id' $mydir/find.xsl $tempsourcefiles 2> /dev/null | sort)

--- a/resolve-conkeyref.xsl
+++ b/resolve-conkeyref.xsl
@@ -32,6 +32,7 @@
    </xsl:when>
    <xsl:otherwise>
     <!-- We don't know it yet, so... -->
+    <xsl:processing-instruction name="suse-conkeyref"><xsl:value-of select="@conkeyref"/></xsl:processing-instruction>
     <xsl:message>Unknown conkeyref ID=<xsl:value-of select="$preid"/> found</xsl:message>
     <xsl:copy-of select="."/>
    </xsl:otherwise>

--- a/resolve-conkeyref.xsl
+++ b/resolve-conkeyref.xsl
@@ -23,7 +23,7 @@
 
   <xsl:choose>
    <!-- We assume filename without .xml is equal to its ID -->
-   <xsl:when test="substring-before($conrefs.file, '.xml') = $preid">
+   <xsl:when test="contains($conrefs.file, $preid)">
     <xsl:message>Resolve conkeyref <xsl:value-of
      select="concat($idkey, ' => ', boolean($node))"/></xsl:message>
     <xsl:element name="{local-name(.)}">

--- a/resolve-conkeyref.xsl
+++ b/resolve-conkeyref.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="1.0"
+ xmlns:exsl="http://exslt.org/common"
+ xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="exsl ditaarch">
+
+ <!-- This points to a file, for example HOS-conrefs.xml -->
+ <xsl:param name="conrefs.file"/>
+ <xsl:variable name="conrefs" select="exsl:node-set(document($conrefs.file, /))"/>
+
+ <xsl:template match="@*|node()" name="copy">
+  <xsl:copy>
+   <xsl:apply-templates select="@* | node()"/>
+  </xsl:copy>
+ </xsl:template>
+
+ <xsl:template match="*[@conkeyref]">
+  <xsl:variable name="preid" select="substring-before(@conkeyref, '/')"/>
+  <xsl:variable name="idkey" select="substring-after(@conkeyref, '/')"/>
+  <xsl:variable name="node" select="$conrefs//*[@id=$idkey]"/>
+
+  <xsl:choose>
+   <!-- We assume filename without .xml is equal to its ID -->
+   <xsl:when test="substring-before($conrefs.file, '.xml') = $preid">
+    <xsl:message>Resolve conkeyref <xsl:value-of
+     select="concat($idkey, ' => ', boolean($node))"/></xsl:message>
+    <xsl:element name="{local-name(.)}">
+     <xsl:apply-templates select="$node"/>
+    </xsl:element>
+   </xsl:when>
+   <xsl:otherwise>
+    <!-- We don't know it yet, so... -->
+    <xsl:message>Unknown conkeyref ID=<xsl:value-of select="$preid"/> found</xsl:message>
+    <xsl:copy-of select="."/>
+   </xsl:otherwise>
+  </xsl:choose>
+ </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
The stylesheet needs a filename passed in parameter `conrefs.file`. It can resolve `conkeyref`s to this file, but not to others.

For example, if the conkeyref is

```
<p conkeyref="foo/bar"/>
```

it will look in the file `foo.xml` with the id `bar`. If there is another `conkeyref` which points to `zzzz/aaaa`, then it can't resolve. You need another run with the `zzzz.xml` passed as parameter.
